### PR TITLE
Refactor: Refactor Groups and SubGroups

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PersonAddSubGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PersonAddSubGroupCommand.java
@@ -62,13 +62,11 @@ public class PersonAddSubGroupCommand extends Command {
             superGroup = new SuperGroup(groupName);
             model.addSuperGroup(superGroup);
         }
-
-        SubGroup subGroup = model.findSubGroup(groupName + "_" + subGroupName);
+        SubGroup subGroup = superGroup.findSubGroup(subGroupName);
         if (subGroup == null) {
             subGroup = new SubGroup(subGroupName, superGroup.getName());
-            model.addSubGroup(subGroup);
+            superGroup.addSubGroup(subGroup);
         }
-        superGroup.addSubGroup(subGroup);
         superGroup.addPerson(personToEdit);
         subGroup.addPerson(personToEdit);
         personToEdit.addSuperGroup(superGroup);

--- a/src/main/java/seedu/address/logic/commands/PersonRemoveGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PersonRemoveGroupCommand.java
@@ -4,8 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.Arrays;
-
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -46,7 +44,6 @@ public class PersonRemoveGroupCommand extends Command {
             throw new CommandException(MESSAGE_NOT_IN_GROUP);
         }
         personToEdit.getSuperGroups().remove(groupName);
-        System.out.println(Arrays.toString(personToEdit.getSubGroups().toArray()));
         personToEdit.getSubGroups().removeIf(subGroup -> subGroup.split("_")[0].equals(groupName));
         model.setPerson(personToEdit, personToEdit);
         return new CommandResult(String.format(MESSAGE_SUCCESS, groupName));

--- a/src/main/java/seedu/address/logic/commands/PersonRemoveSubGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PersonRemoveSubGroupCommand.java
@@ -52,7 +52,10 @@ public class PersonRemoveSubGroupCommand extends Command {
             throw new CommandException(MESSAGE_NOT_IN_SUBGROUP);
         }
         personToEdit.getSubGroups().remove(groupName + "_" + subGroupName);
-        SubGroup subGroup = model.findSubGroup(groupName + "_" + subGroupName);
+        SubGroup subGroup = model.findSuperGroup(groupName).findSubGroup(subGroupName);
+        if (subGroup == null) {
+            throw new CommandException(MESSAGE_NOT_IN_SUBGROUP);
+        }
         subGroup.getPeople().remove(personName);
         model.setPerson(personToEdit, personToEdit);
         return new CommandResult(String.format(MESSAGE_SUCCESS, groupName + "_" + subGroupName));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,11 +2,9 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashMap;
 import java.util.List;
 
 import javafx.collections.ObservableList;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 import seedu.address.model.util.UniqueList;
@@ -19,9 +17,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueList<Person> persons;
 
-    private HashMap<String, SuperGroup> superGroups;
-
-    private HashMap<String, SubGroup> subGroups;
+    private final UniqueList<SuperGroup> superGroups;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -32,8 +28,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniqueList<>();
-        superGroups = new HashMap<>();
-        subGroups = new HashMap<>();
+        superGroups = new UniqueList<>();
     }
 
     public AddressBook() {}
@@ -60,16 +55,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Replaces the contents of the person list with {@code SuperGroups}.
      * {@code SuperGroups} must not contain duplicate SuperGroups.
      */
-    public void setSuperGroups(HashMap<String, SuperGroup> superGroups) {
-        this.superGroups = superGroups;
-    }
-
-    /**
-     * Replaces the contents of the person list with {@code SuperGroups}.
-     * {@code SuperGroups} must not contain duplicate SuperGroups.
-     */
-    public void setSubGroups(HashMap<String, SubGroup> subGroups) {
-        this.subGroups = subGroups;
+    public void setSuperGroups(List<SuperGroup> superGroups) {
+        this.superGroups.setItems(superGroups);
     }
 
     /**
@@ -80,7 +67,6 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         setPersons(newData.getPersonList());
         setSuperGroups(newData.getSuperGroups());
-        setSubGroups(newData.getSubGroups());
     }
 
     //// person-level operations
@@ -139,48 +125,23 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param sg the SuperGroup to be added into AddressBook.
      */
     public void addSuperGroup(SuperGroup sg) {
-        if (!superGroups.containsKey(sg.getName())) {
-            superGroups.put(sg.getName(), sg);
-        }
+        superGroups.add(sg);
     }
 
     public void deleteSuperGroup(SuperGroup sg) {
-        superGroups.remove(sg.getName());
+        superGroups.remove(sg);
     }
 
     /**
      * Gets SuperGroup based on group name.
      */
     public SuperGroup findSuperGroup(String name) {
-        return superGroups.get(name);
-    }
-
-    /**
-     * Returns true if SuperGroup exists.
-     */
-    public boolean hasSubGroup(SubGroup subGroup) {
-        requireNonNull(subGroup);
-        return subGroups.containsKey(subGroup.toString());
-    }
-
-    /**
-     * Adds SubGroup into the AddressBook.
-     * @param subGroup the SuperGroup to be added into AddressBook.
-     */
-    public void addSubGroup(SubGroup subGroup) {
-        requireNonNull(subGroup);
-        subGroups.put(subGroup.toString(), subGroup);
-    }
-
-    public void deleteSubGroup(SubGroup subGroup) {
-        subGroups.remove(subGroup.toString());
-    }
-
-    /**
-     * Gets SuperGroup based on group name.
-     */
-    public SubGroup findSubGroup(String name) {
-        return subGroups.get(name);
+        for (SuperGroup superGroup: superGroups) {
+            if (superGroup.getName().equals(name)) {
+                return superGroup;
+            }
+        }
+        return null;
     }
 
     /**
@@ -188,7 +149,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public boolean hasSuperGroup(SuperGroup superGroup) {
         requireNonNull(superGroup);
-        return superGroups.containsKey(superGroup.getName());
+        return superGroups.contains(superGroup);
     }
 
 
@@ -206,13 +167,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public HashMap<String, SuperGroup> getSuperGroups() {
-        return superGroups;
-    }
-
-    @Override
-    public HashMap<String, SubGroup> getSubGroups() {
-        return subGroups;
+    public ObservableList<SuperGroup> getSuperGroups() {
+        return superGroups.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 
@@ -93,12 +92,6 @@ public interface Model {
     void deleteSuperGroup(SuperGroup superGroup);
 
     SuperGroup findSuperGroup(String name);
-
-    SubGroup findSubGroup(String name);
-
-    void addSubGroup(SubGroup subGroup);
-
-    void deleteSubGroup(SubGroup subGroup);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,5 +1,4 @@
 package seedu.address.model;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
@@ -11,7 +10,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 
@@ -140,23 +138,6 @@ public class ModelManager implements Model {
     @Override
     public SuperGroup findSuperGroup(String name) {
         return addressBook.findSuperGroup(name);
-    }
-
-    @Override
-    public SubGroup findSubGroup(String name) {
-        return addressBook.findSubGroup(name);
-    }
-
-    @Override
-    public void addSubGroup(SubGroup subGroup) {
-        addressBook.addSubGroup(subGroup);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-    }
-
-    @Override
-    public void deleteSubGroup(SubGroup subGroup) {
-        addressBook.deleteSubGroup(subGroup);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,9 +1,6 @@
 package seedu.address.model;
 
-import java.util.HashMap;
-
 import javafx.collections.ObservableList;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 
@@ -18,7 +15,5 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
-    HashMap<String, SuperGroup> getSuperGroups();
-
-    HashMap<String, SubGroup> getSubGroups();
+    ObservableList<SuperGroup> getSuperGroups();
 }

--- a/src/main/java/seedu/address/model/group/SubGroup.java
+++ b/src/main/java/seedu/address/model/group/SubGroup.java
@@ -2,10 +2,12 @@ package seedu.address.model.group;
 
 import java.util.Objects;
 
+import seedu.address.model.util.Unique;
+
 /**
  * Represents a group that can be part of a SuperGroup.
  */
-public class SubGroup extends Group {
+public class SubGroup extends Group implements Unique<SubGroup> {
 
     protected String parent;
     /**
@@ -35,5 +37,11 @@ public class SubGroup extends Group {
 
     public String getParent() {
         return parent;
+    }
+
+
+    @Override
+    public boolean isSame(SubGroup other) {
+        return other.toString().equals(this.toString());
     }
 }

--- a/src/main/java/seedu/address/model/group/SuperGroup.java
+++ b/src/main/java/seedu/address/model/group/SuperGroup.java
@@ -2,15 +2,15 @@ package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.HashSet;
+import seedu.address.model.person.Person;
+import seedu.address.model.util.Unique;
+import seedu.address.model.util.UniqueList;
 
 /**
  * Represents a group that has many subgroups.
  */
-public class SuperGroup extends Group {
-
-    protected HashSet<String> subGroups;
+public class SuperGroup extends Group implements Unique<SuperGroup> {
+    protected UniqueList<SubGroup> subGroups;
 
     /**
      * Creates a new SuperGroup where name is the name of the group.
@@ -19,7 +19,7 @@ public class SuperGroup extends Group {
      */
     public SuperGroup(String name) {
         super(name);
-        subGroups = new HashSet<>();
+        subGroups = new UniqueList<>();
     }
 
     public String getName() {
@@ -32,15 +32,38 @@ public class SuperGroup extends Group {
      */
     public void addSubGroup(SubGroup subGroup) {
         requireNonNull(subGroup);
-        subGroups.add(subGroup.name);
+        subGroups.add(subGroup);
     }
 
-    public ArrayList<String> getSubGroups() {
-        return new ArrayList<>(subGroups);
+    public UniqueList<SubGroup> getSubGroups() {
+        return subGroups;
+    }
+
+    /**
+     * Finds the SubGroup given the SubGroup name.
+     * @param name the Name of the SubGroup.
+     * @return SubGroup
+     */
+    public SubGroup findSubGroup(String name) {
+        for (SubGroup subGroup: subGroups) {
+            if (subGroup.name.equals(name)) {
+                return subGroup;
+            }
+        }
+        return null;
+    }
+
+    public void addPersonToSubGroup(String subGroupName, Person p) {
+        findSubGroup(subGroupName).addPerson(p);
     }
 
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public boolean isSame(SuperGroup other) {
+        return other.name.equals(this.name);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedSuperGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSuperGroup.java
@@ -1,11 +1,13 @@
 package seedu.address.storage;
+
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 
 public class JsonAdaptedSuperGroup {
@@ -13,16 +15,16 @@ public class JsonAdaptedSuperGroup {
 
     private final String name;
 
-    private ArrayList<String> subGroups;
+    private List<JsonAdaptedSubGroup> subGroups = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedSuperGroup} with the given group details.
      */
     @JsonCreator
     public JsonAdaptedSuperGroup(@JsonProperty("name") String name,
-        @JsonProperty("subGroups") ArrayList<String> subGroups) {
+        @JsonProperty("subGroups") List<JsonAdaptedSubGroup> subGroups) {
         this.name = name;
-        this.subGroups = subGroups;
+        this.subGroups.addAll(subGroups);
     }
 
     /**
@@ -30,7 +32,9 @@ public class JsonAdaptedSuperGroup {
      */
     public JsonAdaptedSuperGroup(SuperGroup source) {
         this.name = source.getName();
-        this.subGroups = source.getSubGroups();
+        subGroups.addAll(source.getSubGroups().asUnmodifiableObservableList().stream()
+            .map(JsonAdaptedSubGroup::new)
+            .collect(Collectors.toList()));
     }
 
     /**
@@ -41,8 +45,8 @@ public class JsonAdaptedSuperGroup {
      */
     public SuperGroup toModelType() throws IllegalValueException {
         SuperGroup group = new SuperGroup(name);
-        for (String sg : this.subGroups) {
-            group.addSubGroup(new SubGroup(sg, group.getName()));
+        for (JsonAdaptedSubGroup subGroup : this.subGroups) {
+            group.addSubGroup(subGroup.toModelType());
         }
         return group;
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 
@@ -26,18 +25,15 @@ class JsonSerializableAddressBook {
 
     private final List<JsonAdaptedSuperGroup> superGroups = new ArrayList<>();
 
-    private final List<JsonAdaptedSubGroup> subGroups = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
     public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
-        @JsonProperty("superGroups") List<JsonAdaptedSuperGroup> superGroups,
-        @JsonProperty("subGroups") List<JsonAdaptedSubGroup> subGroups) {
+        @JsonProperty("superGroups") List<JsonAdaptedSuperGroup> superGroups) {
         this.persons.addAll(persons);
         this.superGroups.addAll(superGroups);
-        this.subGroups.addAll(subGroups);
     }
 
     /**
@@ -49,11 +45,8 @@ class JsonSerializableAddressBook {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(
             Collectors.toList()));
         superGroups
-            .addAll(source.getSuperGroups().values().stream().map(JsonAdaptedSuperGroup::new).collect(
+            .addAll(source.getSuperGroups().stream().map(JsonAdaptedSuperGroup::new).collect(
             Collectors.toList()));
-        subGroups
-            .addAll(source.getSubGroups().values().stream().map(JsonAdaptedSubGroup::new).collect(
-                Collectors.toList()));
     }
 
     /**
@@ -69,12 +62,6 @@ class JsonSerializableAddressBook {
                 addressBook.addSuperGroup(superGroup);
             }
         }
-        for (JsonAdaptedSubGroup jsonAdaptedSubGroups : subGroups) {
-            SubGroup subGroup = jsonAdaptedSubGroups.toModelType();
-            if (!addressBook.hasSubGroup(subGroup)) {
-                addressBook.addSubGroup(subGroup);
-            }
-        }
 
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();
@@ -85,7 +72,9 @@ class JsonSerializableAddressBook {
                 addressBook.findSuperGroup(superGroup).addPerson(person);
             }
             for (String subGroup : person.getSubGroups()) {
-                addressBook.findSubGroup(subGroup).addPerson(person);
+                String[] split = subGroup.split("_");
+                // TODO: Create method to check for validity
+                addressBook.findSuperGroup(split[0]).addPersonToSubGroup(split[1], person);
             }
 
             addressBook.addPerson(person);

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -18,6 +18,5 @@
     "superGroups" : [ ],
     "subGroups" : [ ]
   } ],
-  "superGroups" : [ ],
-  "subGroups" : [ ]
+  "superGroups" : [ ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -9,6 +9,5 @@
     "superGroups" : [ ],
     "subGroups" : [ ]
   } ],
-  "superGroups" : [ ],
-  "subGroups" : [ ]
+  "superGroups" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -18,6 +18,5 @@
     "superGroups" : [ ],
     "subGroups" : [ ]
   } ],
-  "superGroups" : [ ],
-  "subGroups" : [ ]
+  "superGroups" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -8,6 +8,5 @@
     "superGroups" : [ ],
     "subGroups" : [ ]
   } ],
-  "superGroups" : [ ],
-  "subGroups" : [ ]
+  "superGroups" : [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -64,6 +64,5 @@
     "superGroups" : [ ],
     "subGroups" : [ ]
   } ],
-  "superGroups" : [ ],
-  "subGroups" : [ ]
+  "superGroups" : [ ]
 }

--- a/src/test/java/seedu/address/logic/commands/PersonCreateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PersonCreateCommandTest.java
@@ -24,7 +24,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
@@ -147,22 +146,7 @@ public class PersonCreateCommandTest {
         }
 
         @Override
-        public void deleteSubGroup(SubGroup subGroup) {
-
-        }
-
-        @Override
-        public void addSubGroup(SubGroup subGroup) {
-
-        }
-
-        @Override
         public SuperGroup findSuperGroup(String name) {
-            return null;
-        }
-
-        @Override
-        public SubGroup findSubGroup(String name) {
             return null;
         }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,8 +1,6 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -10,13 +8,10 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-
-import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.group.SubGroup;
+import org.junit.jupiter.api.Test;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
@@ -88,12 +83,7 @@ public class AddressBookTest {
         }
 
         @Override
-        public HashMap<String, SuperGroup> getSuperGroups() {
-            return null;
-        }
-
-        @Override
-        public HashMap<String, SubGroup> getSubGroups() {
+        public ObservableList<SuperGroup> getSuperGroups() {
             return null;
         }
     }

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -11,7 +11,9 @@ public class TypicalGroups {
 
 
     public static final List<SuperGroup> getSuperGroups() {
-        ORBITAL.addSubGroup(TypicalSubGroups.ORBITAL_GROUP1);
+        if (ORBITAL.findSubGroup("Group1") == null) {
+            ORBITAL.addSubGroup(TypicalSubGroups.ORBITAL_GROUP1);
+        }
         ArrayList<SuperGroup> temp = new ArrayList<>();
         temp.add(ORBITAL);
         temp.add(CS2103);

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,20 +1,12 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
-import seedu.address.model.group.SubGroup;
 import seedu.address.model.group.SuperGroup;
 import seedu.address.model.person.Person;
 
@@ -82,9 +74,6 @@ public class TypicalPersons {
         AddressBook ab = new AddressBook();
         for (SuperGroup superGroup: TypicalGroups.getSuperGroups()) {
             ab.addSuperGroup(superGroup);
-        }
-        for (SubGroup subGroup: TypicalSubGroups.getSubGroups()) {
-            ab.addSubGroup(subGroup);
         }
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);


### PR DESCRIPTION
Refactored some parts of groups after discussion with Yukun.

1. Due to hassle of initialising both Group and SubGroup together, SubGroup will still have String parent name. (I hope that is fine hahahahaha) I think should be okay since we probably wont reference group from subgroup. It is more of to identify subgroup.
2. I think UniqueList should not use HashMap. I think we should just loop through and find the object. Unless, we are sure that we will not be renaming groups. I am afraid that when we rename objects, we may forgot to rename the string in HashMap. 
3. I think Person should have SubGroup and Group List separated. In the person card, we should be able to see the subgroups too. Do we want to put subgroup and groups together. 