### PR TITLE
Fix: Clear Note

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -15,6 +15,10 @@ Class PersonListPanel
 Class PersonCard
 Class StatusBarFooter
 Class CommandBox
+Class GeneralNoteWindow
+Class PersonNoteWindow
+Class GroupNoteWindow
+Class "{abstract}\nNoteWindow" as NoteWindow
 }
 
 package Model <<Rectangle>> {
@@ -35,7 +39,13 @@ MainWindow *-down-> "1" ResultDisplay
 MainWindow *-down-> "1" PersonListPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
+MainWindow --> "0..1" GeneralNoteWindow
+MainWindow --> "0..*" PersonNoteWindow
+MainWindow --> "0..*" GroupNoteWindow
 
+GroupNoteWindow --|> NoteWindow
+PersonNoteWindow --|> NoteWindow
+GeneralNoteWindow --|> NoteWindow
 PersonListPanel -down-> "*" PersonCard
 
 MainWindow -left-|> UiPart
@@ -46,10 +56,15 @@ PersonListPanel --|> UiPart
 PersonCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
+NoteWindow --|> UiPart
 
 PersonCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
+NoteWindow --> Logic
+GeneralNoteWindow --> Logic
+PersonNoteWindow --> Logic
+GroupNoteWindow --> Logic
 
 PersonListPanel -[hidden]left- HelpWindow
 HelpWindow -[hidden]left- CommandBox

--- a/src/main/java/seedu/notor/logic/commands/ClearNoteCommand.java
+++ b/src/main/java/seedu/notor/logic/commands/ClearNoteCommand.java
@@ -3,8 +3,11 @@ package seedu.notor.logic.commands;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.notor.logic.executors.exceptions.ExecuteException;
 import seedu.notor.model.Model;
+import seedu.notor.model.common.Note;
 import seedu.notor.ui.WarningWindow;
+import seedu.notor.ui.note.NoteWindow;
 
 /**
  * Clears general note.
@@ -16,13 +19,19 @@ public class ClearNoteCommand implements Command {
     public static final String MESSAGE_CLEAR_NOTE_SUCCESS = "Cleared general note.";
     public static final String MESSAGE_CLEAR_NOTE_CANCEL = "Clearing of general note has been cancelled.";
     public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with clearing general note?";
+    public static final String MESSAGE_CANNOT_CLEAR_NOTE =
+            "Unable to clear general note as general note window is currently opened.";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model)throws ExecuteException {
+        if (NoteWindow.contains(model.getNotor())) {
+            throw new ExecuteException(MESSAGE_CANNOT_CLEAR_NOTE);
+        }
         WarningWindow warningWindow = new WarningWindow(CONFIRMATION_MESSAGE);
         warningWindow.show();
         if (warningWindow.canContinue()) {
             model.clearNotorNote();
+            assert model.getNotor().getNote() == Note.EMPTY_NOTE;
             return new CommandResult(MESSAGE_CLEAR_NOTE_SUCCESS);
         }
         return new CommandResult(MESSAGE_CLEAR_NOTE_CANCEL);

--- a/src/main/java/seedu/notor/logic/executors/group/GroupClearNoteExecutor.java
+++ b/src/main/java/seedu/notor/logic/executors/group/GroupClearNoteExecutor.java
@@ -8,13 +8,16 @@ import seedu.notor.logic.executors.exceptions.ExecuteException;
 import seedu.notor.model.common.Note;
 import seedu.notor.model.group.Group;
 import seedu.notor.ui.WarningWindow;
+import seedu.notor.ui.note.NoteWindow;
 
 /**
  * Executor for a GroupClearNoteCommand.
  */
 public class GroupClearNoteExecutor extends GroupExecutor {
-    public static final String MESSAGE_CLEAR_GROUP_NOTE_SUCCESS = "Opened note for Group: %1$s";
+    public static final String MESSAGE_CLEAR_GROUP_NOTE_SUCCESS = "Cleared note for Group: %1$s.";
     public static final String MESSAGE_CLEAR_GROUP_NOTE_CANCEL = "Clearing of Note for Group: %1$s has been cancelled.";
+    public static final String MESSAGE_CLEAR_GROUP_NOTE_FAILURE =
+            "Unable to clear note as note window for Group: %1$s is currently opened.";
     public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with Clearing of Note for Group: %1$s?";
 
 
@@ -32,10 +35,14 @@ public class GroupClearNoteExecutor extends GroupExecutor {
     @Override
     public CommandResult execute() throws ExecuteException {
         Group group = super.getGroup();
+        if (NoteWindow.contains(group)) {
+            throw new ExecuteException(generateFailureMessage(group));
+        }
         WarningWindow warningWindow = new WarningWindow(String.format(CONFIRMATION_MESSAGE, group));
         warningWindow.show();
         if (warningWindow.canContinue()) {
             group.setNote(Note.EMPTY_NOTE);
+            assert group.getNote() == Note.EMPTY_NOTE;
             return new CommandResult(String.format(MESSAGE_CLEAR_GROUP_NOTE_SUCCESS, group));
         }
         return new CommandResult(MESSAGE_CLEAR_GROUP_NOTE_CANCEL);
@@ -43,11 +50,20 @@ public class GroupClearNoteExecutor extends GroupExecutor {
 
     /**
      * Generates a command execution success message based on whether
-     * the note is added.
-     * {@code personToEdit}.
+     * the note is cleared.
+     * {@code group}.
      */
     private String generateSuccessMessage(Group group) {
         return String.format(MESSAGE_CLEAR_GROUP_NOTE_SUCCESS, group);
+    }
+
+    /**
+     * Generates a command execution failure message based on whether
+     * the note is cleared.
+     * {@code group}.
+     */
+    private String generateFailureMessage(Group group) {
+        return String.format(MESSAGE_CLEAR_GROUP_NOTE_FAILURE, group);
     }
 
     @Override

--- a/src/main/java/seedu/notor/logic/executors/person/PersonClearNoteExecutor.java
+++ b/src/main/java/seedu/notor/logic/executors/person/PersonClearNoteExecutor.java
@@ -8,14 +8,18 @@ import seedu.notor.logic.executors.exceptions.ExecuteException;
 import seedu.notor.model.common.Note;
 import seedu.notor.model.person.Person;
 import seedu.notor.ui.WarningWindow;
+import seedu.notor.ui.note.NoteWindow;
 
 /**
  * Executor for a PersonNoteCommand.
  */
 public class PersonClearNoteExecutor extends PersonExecutor {
-    public static final String MESSAGE_CLEAR_NOTE_SUCCESS = "Cleared note of Person: %1$s";
+    public static final String MESSAGE_CLEAR_NOTE_SUCCESS = "Cleared note of Person: %1$s.";
     public static final String MESSAGE_CLEAR_NOTE_CANCEL = "Clearing of note for %1$s has been cancelled.";
+    public static final String MESSAGE_CLEAR_NOTE_FAILURE =
+            "Unable to clear note as note window for Person: %1$s is currently opened.";
     public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with clearing note of Person: %1$s?";
+
 
 
     /**
@@ -33,6 +37,9 @@ public class PersonClearNoteExecutor extends PersonExecutor {
     public CommandResult execute() throws ExecuteException {
         checkPersonList();
         Person storedPerson = super.getPerson();
+        if (NoteWindow.contains(storedPerson)) {
+            throw new ExecuteException(generateFailureMessage(storedPerson));
+        }
         WarningWindow warningWindow = new WarningWindow(String.format(CONFIRMATION_MESSAGE,
                 storedPerson.getName()));
         warningWindow.show();
@@ -40,7 +47,8 @@ public class PersonClearNoteExecutor extends PersonExecutor {
             Person editedPerson = new Person(
                     storedPerson.getName(), storedPerson.getPhone(), storedPerson.getEmail(),
                     Note.EMPTY_NOTE, storedPerson.getTags());
-            model.setPerson(editedPerson, editedPerson);
+            model.setPerson(storedPerson, editedPerson);
+            assert editedPerson.getNote() == Note.EMPTY_NOTE;
             return new CommandResult(generateSuccessMessage(editedPerson), false, false, false);
         }
         return new CommandResult(String.format(MESSAGE_CLEAR_NOTE_CANCEL, storedPerson));
@@ -48,11 +56,20 @@ public class PersonClearNoteExecutor extends PersonExecutor {
 
     /**
      * Generates a command execution success message based on whether
-     * the note is added.
+     * the note is cleared.
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(Person personToEdit) {
         return String.format(MESSAGE_CLEAR_NOTE_SUCCESS, personToEdit);
+    }
+
+    /**
+     * Generates a command execution success message based on whether
+     * the note is cleared.
+     * {@code personToEdit}.
+     */
+    private String generateFailureMessage(Person personToEdit) {
+        return String.format(MESSAGE_CLEAR_NOTE_FAILURE, personToEdit);
     }
 
     @Override

--- a/src/main/java/seedu/notor/logic/executors/person/PersonClearNoteExecutor.java
+++ b/src/main/java/seedu/notor/logic/executors/person/PersonClearNoteExecutor.java
@@ -17,8 +17,8 @@ public class PersonClearNoteExecutor extends PersonExecutor {
     public static final String MESSAGE_CLEAR_NOTE_SUCCESS = "Cleared note of Person: %1$s.";
     public static final String MESSAGE_CLEAR_NOTE_CANCEL = "Clearing of note for %1$s has been cancelled.";
     public static final String MESSAGE_CLEAR_NOTE_FAILURE =
-            "Unable to clear note as note window for Person: %1$s is currently opened.";
-    public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with clearing note of Person: %1$s?";
+            "Unable to clear note.\nPlease close the note of Person: %1$s";
+    public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with clearing the note of Person: %1$s?";
 
 
 

--- a/src/main/java/seedu/notor/ui/CommandBox.java
+++ b/src/main/java/seedu/notor/ui/CommandBox.java
@@ -79,7 +79,7 @@ public class CommandBox extends UiPart<Region> {
         } else {
             return;
         }
-        commandTextField.setText(commandHistory.getCommandText());
+        commandTextField.setText(commandHistory.getCommandText(commandTextField.getText()));
     }
 
     /**
@@ -131,11 +131,13 @@ public class CommandBox extends UiPart<Region> {
             return commandHistory.size();
         }
 
-        String getCommandText() {
+        String getCommandText(String curCommandText) {
             if (index > 0) {
                 return commandHistory.get(historyLength() - index);
-            } else {
+            } else if (index == 0 && historyLength() > 0) {
                 return "";
+            } else {
+                return curCommandText;
             }
         }
 

--- a/src/main/java/seedu/notor/ui/note/GeneralNoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/GeneralNoteWindow.java
@@ -7,7 +7,6 @@ import seedu.notor.logic.commands.exceptions.CommandException;
 import seedu.notor.model.Notable;
 import seedu.notor.model.Notor;
 import seedu.notor.model.common.Note;
-import seedu.notor.model.group.Group;
 import seedu.notor.ui.ConfirmationWindow;
 import seedu.notor.ui.ResultDisplay;
 import seedu.notor.ui.view.ViewPanel;

--- a/src/main/java/seedu/notor/ui/note/GeneralNoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/GeneralNoteWindow.java
@@ -4,8 +4,10 @@ import javafx.fxml.FXML;
 import javafx.scene.layout.StackPane;
 import seedu.notor.logic.Logic;
 import seedu.notor.logic.commands.exceptions.CommandException;
+import seedu.notor.model.Notable;
 import seedu.notor.model.Notor;
 import seedu.notor.model.common.Note;
+import seedu.notor.model.group.Group;
 import seedu.notor.ui.ConfirmationWindow;
 import seedu.notor.ui.ResultDisplay;
 import seedu.notor.ui.view.ViewPanel;
@@ -61,6 +63,7 @@ public class GeneralNoteWindow extends NoteWindow {
         ViewPanel viewPane = new ViewPanel(logic.getNotor().getNote());
         notePane.getChildren().add(viewPane.getRoot());
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_SAVE_NOTE_SUCCESS));
+        logger.info(MESSAGE_SAVE_NOTE_SUCCESS);
     }
 
 
@@ -82,8 +85,17 @@ public class GeneralNoteWindow extends NoteWindow {
             return false;
         }
 
-        GeneralNoteWindow otherPerson = (GeneralNoteWindow) other;
-        return otherPerson.notor.equals(this.notor);
+        GeneralNoteWindow otherGeneralNoteWindow = (GeneralNoteWindow) other;
+        return otherGeneralNoteWindow.notor.equals(this.notor);
+    }
+
+    @Override
+    public boolean belongsTo(Notable notable) {
+        if (notable instanceof Notor) {
+            Notor otherNotor = (Notor) notable;
+            return otherNotor.equals(notor);
+        }
+        return false;
     }
 
     /**
@@ -94,5 +106,6 @@ public class GeneralNoteWindow extends NoteWindow {
         getRoot().close();
         OPENED_NOTE_WINDOWS.remove(this);
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_EXIT_NOTE_SUCCESS));
+        logger.info(MESSAGE_EXIT_NOTE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/notor/ui/note/GroupNoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/GroupNoteWindow.java
@@ -7,7 +7,6 @@ import seedu.notor.logic.commands.exceptions.CommandException;
 import seedu.notor.model.Notable;
 import seedu.notor.model.common.Note;
 import seedu.notor.model.group.Group;
-import seedu.notor.model.person.Person;
 import seedu.notor.ui.ConfirmationWindow;
 import seedu.notor.ui.ResultDisplay;
 import seedu.notor.ui.listpanel.GroupListPanel;

--- a/src/main/java/seedu/notor/ui/note/GroupNoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/GroupNoteWindow.java
@@ -4,8 +4,10 @@ import javafx.fxml.FXML;
 import javafx.scene.layout.StackPane;
 import seedu.notor.logic.Logic;
 import seedu.notor.logic.commands.exceptions.CommandException;
+import seedu.notor.model.Notable;
 import seedu.notor.model.common.Note;
 import seedu.notor.model.group.Group;
+import seedu.notor.model.person.Person;
 import seedu.notor.ui.ConfirmationWindow;
 import seedu.notor.ui.ResultDisplay;
 import seedu.notor.ui.listpanel.GroupListPanel;
@@ -13,8 +15,8 @@ import seedu.notor.ui.listpanel.SubgroupListPanel;
 
 public class GroupNoteWindow extends NoteWindow {
 
-    private static final String MESSAGE_SAVE_NOTE_SUCCESS = "Saved Note to Group: %1$s";
-    private static final String MESSAGE_EXIT_NOTE_SUCCESS = "Exited Note of Group: %1$s";
+    private static final String MESSAGE_SAVE_NOTE_SUCCESS = "Saved Note to Group: %1$s.";
+    private static final String MESSAGE_EXIT_NOTE_SUCCESS = "Exited Note of Group: %1$s.";
 
     private final Group group;
     private final StackPane listPanelPlaceholder;
@@ -47,7 +49,7 @@ public class GroupNoteWindow extends NoteWindow {
     }
 
     /**
-     * Saves the file
+     * Saves the file.
      */
     @FXML
     @Override
@@ -66,6 +68,7 @@ public class GroupNoteWindow extends NoteWindow {
         group.setNote(editedNote);
         logic.executeSaveNote();
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_SAVE_NOTE_SUCCESS));
+        logger.info(String.format(MESSAGE_SAVE_NOTE_SUCCESS, group));
     }
 
 
@@ -91,6 +94,15 @@ public class GroupNoteWindow extends NoteWindow {
         return otherGroup.group.equals(this.group);
     }
 
+    @Override
+    public boolean belongsTo(Notable notable) {
+        if (notable instanceof Group) {
+            Group otherGroup = (Group) notable;
+            return otherGroup.equals(group);
+        }
+        return false;
+    }
+
     /**
      * Exits the note Window.
      */
@@ -99,5 +111,6 @@ public class GroupNoteWindow extends NoteWindow {
         getRoot().close();
         OPENED_NOTE_WINDOWS.remove(this);
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_EXIT_NOTE_SUCCESS));
+        logger.info(generateSuccessMessage(MESSAGE_EXIT_NOTE_SUCCESS));
     }
 }

--- a/src/main/java/seedu/notor/ui/note/NoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/NoteWindow.java
@@ -2,6 +2,7 @@ package seedu.notor.ui.note;
 
 import java.awt.Toolkit;
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
@@ -11,9 +12,11 @@ import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyCombination.Modifier;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
+import seedu.notor.commons.core.LogsCenter;
 import seedu.notor.commons.util.DateUtil;
 import seedu.notor.logic.Logic;
 import seedu.notor.logic.commands.exceptions.CommandException;
+import seedu.notor.model.Notable;
 import seedu.notor.model.person.Person;
 import seedu.notor.ui.ConfirmationWindow;
 import seedu.notor.ui.ResultDisplay;
@@ -41,12 +44,13 @@ public abstract class NoteWindow extends UiPart<Stage> {
     @FXML
     protected TextArea noteTextArea;
 
-
     protected ConfirmationWindow confirmationWindow;
 
     protected final Logic logic;
 
     protected final ResultDisplay resultDisplay;
+
+    protected final Logger logger = LogsCenter.getLogger(getClass());
 
     protected NoteWindow(Logic logic, ResultDisplay resultDisplay) {
         super(FXML);
@@ -134,6 +138,12 @@ public abstract class NoteWindow extends UiPart<Stage> {
      * Exits the note Window.
      */
     public abstract void exit();
+
+    public abstract boolean belongsTo(Notable notable);
+
+    public static boolean contains(Notable notable) {
+        return OPENED_NOTE_WINDOWS.parallelStream().anyMatch(noteWindow -> noteWindow.belongsTo(notable));
+    }
 
     /**
      * Exits and saves the note window.

--- a/src/main/java/seedu/notor/ui/note/PersonNoteWindow.java
+++ b/src/main/java/seedu/notor/ui/note/PersonNoteWindow.java
@@ -3,6 +3,7 @@ package seedu.notor.ui.note;
 import javafx.fxml.FXML;
 import seedu.notor.logic.Logic;
 import seedu.notor.logic.commands.exceptions.CommandException;
+import seedu.notor.model.Notable;
 import seedu.notor.model.common.Note;
 import seedu.notor.model.person.Person;
 import seedu.notor.ui.ConfirmationWindow;
@@ -10,8 +11,8 @@ import seedu.notor.ui.ResultDisplay;
 
 public class PersonNoteWindow extends NoteWindow {
 
-    private static final String MESSAGE_SAVE_NOTE_SUCCESS = "Saved Note to Person: %1$s";
-    private static final String MESSAGE_EXIT_NOTE_SUCCESS = "Exited Note of Person: %1$s";
+    private static final String MESSAGE_SAVE_NOTE_SUCCESS = "Saved Note to Person: %1$s.";
+    private static final String MESSAGE_EXIT_NOTE_SUCCESS = "Exited Note of Person: %1$s.";
 
     private Person person;
 
@@ -56,6 +57,7 @@ public class PersonNoteWindow extends NoteWindow {
         logic.executeSaveNote(person, editedPerson);
         person = editedPerson;
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_SAVE_NOTE_SUCCESS));
+        logger.info(generateSuccessMessage(MESSAGE_SAVE_NOTE_SUCCESS));
     }
 
 
@@ -81,6 +83,14 @@ public class PersonNoteWindow extends NoteWindow {
         return otherPerson.person.equals(this.person);
 
     }
+    @Override
+    public boolean belongsTo(Notable notable) {
+        if (notable instanceof Person) {
+            Person otherPerson = (Person) notable;
+            return otherPerson.equals(person);
+        }
+        return false;
+    }
 
     /**
      * Exits the note Window.
@@ -90,5 +100,6 @@ public class PersonNoteWindow extends NoteWindow {
         getRoot().close();
         OPENED_NOTE_WINDOWS.remove(this);
         resultDisplay.setFeedbackToUser(generateSuccessMessage(MESSAGE_EXIT_NOTE_SUCCESS));
+        logger.info(generateSuccessMessage(MESSAGE_EXIT_NOTE_SUCCESS));
     }
 }


### PR DESCRIPTION
- [x] Make Notor unable to clear note when note window is opened. #227
- [x] #154
- [ ] Make CommandHistory unable to go to empty line when pressed up when there is no command history. (The previous behaviour is unintended, but I still allow user to go to empty line when they are traversing all the way down, pls let me know I should disable this too!) 


I also added more loggings for note commands, and added assertions to make sure that note is empty when clear note.
Will be working on DG tmr