### PR TITLE
Fix: Fix Deleting Group and Person is possible when NoteWindow is opened

### DIFF
--- a/src/main/java/seedu/notor/logic/executors/group/GroupDeleteExecutor.java
+++ b/src/main/java/seedu/notor/logic/executors/group/GroupDeleteExecutor.java
@@ -8,10 +8,13 @@ import seedu.notor.model.group.Group;
 import seedu.notor.model.group.SubGroup;
 import seedu.notor.model.group.SuperGroup;
 import seedu.notor.ui.WarningWindow;
+import seedu.notor.ui.note.NoteWindow;
 
 public class GroupDeleteExecutor extends GroupExecutor {
     public static final String MESSAGE_DELETE_GROUP_SUCCESS = "Deleted Group: %1$s";
     public static final String MESSAGE_DELETE_GROUP_CANCEL = "Deleting of Group: %1$s has been cancelled.";
+    public static final String MESSAGE_DELETE_GROUP_FAILURE =
+            "Unable to delete Group: %1$s as note window for the Group is currently opened.";
     public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with deleting of Group: %1$s?";
 
 
@@ -22,6 +25,9 @@ public class GroupDeleteExecutor extends GroupExecutor {
     @Override
     public CommandResult execute() throws ExecuteException {
         Group deletedGroup = super.getGroup();
+        if (NoteWindow.contains(deletedGroup)) {
+            throw new ExecuteException(String.format(MESSAGE_DELETE_GROUP_FAILURE, deletedGroup));
+        }
         WarningWindow warningWindow = new WarningWindow(String.format(CONFIRMATION_MESSAGE, deletedGroup));
         warningWindow.show();
         if (warningWindow.canContinue()) {

--- a/src/main/java/seedu/notor/logic/executors/person/PersonDeleteExecutor.java
+++ b/src/main/java/seedu/notor/logic/executors/person/PersonDeleteExecutor.java
@@ -5,10 +5,13 @@ import seedu.notor.logic.commands.CommandResult;
 import seedu.notor.logic.executors.exceptions.ExecuteException;
 import seedu.notor.model.person.Person;
 import seedu.notor.ui.WarningWindow;
+import seedu.notor.ui.note.NoteWindow;
 
 public class PersonDeleteExecutor extends PersonExecutor {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_PERSON_CANCEL = "Deleting of Person: %1$s has been cancelled.";
+    public static final String MESSAGE_DELETE_PERSON_FAILURE =
+            "Unable to delete Person: %1$s as note window for the person is currently opened.";
     public static final String CONFIRMATION_MESSAGE = "Do you want to proceed with deleting Person: %1$s?";
 
 
@@ -20,6 +23,9 @@ public class PersonDeleteExecutor extends PersonExecutor {
     public CommandResult execute() throws ExecuteException {
         checkPersonList();
         Person toBeDeletedPerson = super.getPerson();
+        if (NoteWindow.contains(toBeDeletedPerson)) {
+            throw new ExecuteException(String.format(MESSAGE_DELETE_PERSON_FAILURE, toBeDeletedPerson));
+        }
         WarningWindow warningWindow = new WarningWindow(String.format(CONFIRMATION_MESSAGE,
                 toBeDeletedPerson.getName()));
         warningWindow.show();

--- a/src/main/resources/view/GroupViewCard.fxml
+++ b/src/main/resources/view/GroupViewCard.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/help_icon.png" />
     </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -17,7 +17,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="200" minWidth="450" onCloseRequest="#handleExit" title="Notor" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="200" minWidth="450" onCloseRequest="#handleExit" title="Notor" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>


### PR DESCRIPTION
I just realised that you can actually delete group or person with their note window opened, which leave 'ghost' note windows with nullpointer exceptions.

Incoming pr by Elton to fix major bugs for sample data.